### PR TITLE
feat: option to keep current window focus when opening bmessages window

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ local opts = {
   buffer_name = "bmessages_buffer",
   -- Don't add user commands for `Bmessages`, `Bmessagesvs`, and `Bmessagessp`.
   disable_create_user_commands = false,
+  -- Don't focus the bmessages window after opening.
+  keep_focus = false,
 }
 ```
 

--- a/doc/bmessages.txt
+++ b/doc/bmessages.txt
@@ -90,5 +90,8 @@ use_timer (default: true) ~
 disable_create_user_commands (default: false) ~
     Don't add user commands for `:Bmessages`, `:Bmessagesvs`, and `:Bmessagessp`.
 
+keep_focus (default: false) ~
+    Don't focus the bmessages window after opening.
+
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:

--- a/lua/bmessages.lua
+++ b/lua/bmessages.lua
@@ -16,6 +16,7 @@ local function with_defaults(options)
 		autoscroll = true,
 		use_timer = true,
 		disable_create_user_commands = false,
+		keep_focus = false,
 	}
 
 	for key, default_value in pairs(defaults) do
@@ -109,8 +110,12 @@ local function create_messages_buffer(new_options)
 
 	M.current_split_type = options.split_type
 
+	local orig_win = options.keep_focus and vim.api.nvim_get_current_win()
+
 	run_vim_cmd(options)
 	create_raw_buffer(options)
+
+	if orig_win then vim.api.nvim_set_current_win(orig_win) end
 
 	local update_fn = update_messages_buffer(options)
 	update_fn()


### PR DESCRIPTION
Hi, thanks for making this handy plugin! I added an option `keep_focus` (default value `false`) that lets you keep your focus on the current window when opening bmessages, let me know what you think.