### PR TITLE
feat: option to set split direction of bmessages window

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ local opts = {
   timer_interval = 1000,
   -- Default split type for the messages buffer ('vsplit' or 'split').
   split_type = "vsplit",
+  -- Default split direction for the messages buffer ('topleft' or 'botright').
+  split_direction = nil,
   -- Size of the vertical split when opening the messages buffer.
   split_size_vsplit = nil,
   -- Size of the horizontal split when opening the messages buffer.

--- a/doc/bmessages.txt
+++ b/doc/bmessages.txt
@@ -69,6 +69,10 @@ split_type (default: "vsplit") ~
     Default split type for the bmessages buffer. Valid values are 'vsplit' and
     'split'.
 
+split_direction (default: nil) ~
+    Default split direction for the bmessages buffer. Valid values are 'topleft' and
+    'botright'.
+
 buffer_name (default: "bmessages_buffer") ~
     Name of the bmessages buffer.
 

--- a/lua/bmessages.lua
+++ b/lua/bmessages.lua
@@ -10,6 +10,7 @@ local function with_defaults(options)
 	local defaults = {
 		timer_interval = 1000,
 		split_type = "vsplit",
+		split_direction = nil,
 		buffer_name = "bmessages_buffer",
 		split_size_vsplit = nil,
 		split_size_split = nil,
@@ -90,6 +91,10 @@ local function run_vim_cmd(options)
 		cmd = cmd .. " | vertical resize " .. options.split_size_vsplit
 	elseif cmd == "split" and options.split_size_split ~= nil then
 		cmd = cmd .. " | resize " .. options.split_size_split
+	end
+
+	if options.split_direction ~= nil then
+		cmd = options.split_direction .. " " .. cmd
 	end
 
 	vim.cmd(cmd .. " | enew")


### PR DESCRIPTION
Added the option `split_direction` (either `topleft` or `botright`) for setting the direction in which to open the bmessages window.