### PR TITLE
feat: set filetype to bmessages

### DIFF
--- a/lua/bmessages.lua
+++ b/lua/bmessages.lua
@@ -81,6 +81,7 @@ local function create_raw_buffer(options)
 	vim.api.nvim_buf_set_name(bufnr, options.buffer_name)
 	vim.api.nvim_set_option_value("buftype", "nofile", { buf = bufnr })
 	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = bufnr })
+	vim.api.nvim_set_option_value("filetype", "bmessages", { buf = bufnr })
 	vim.api.nvim_set_option_value("bl", false, { buf = bufnr })
 	vim.api.nvim_set_option_value("swapfile", false, { buf = bufnr })
 end


### PR DESCRIPTION
Set `filetype` so that users can do things with it, for example in my config:

```lua
vim.api.autocmd({ "FileType" }, {
    desc = "Close with q",
    pattern = { "bmessages" },
    callback = function(event)
        vim.schedule(function()
            vim.keymap.set("n", "q", function()
                vim.cmd("close")
            end, {
                buffer = event.buf,
                silent = true,
                desc = "Quit buffer",
            })
        end)
    end,
})
```